### PR TITLE
DBの設定

### DIFF
--- a/src/main/java/oit/is/z1732/kaizi/janken/security/JankenAuthConfiguration.java
+++ b/src/main/java/oit/is/z1732/kaizi/janken/security/JankenAuthConfiguration.java
@@ -29,8 +29,13 @@ public class JankenAuthConfiguration {
             .logoutUrl("/logout")
             .logoutSuccessUrl("/")) // ログアウト後に / にリダイレクト
         .authorizeHttpRequests(authz -> authz
-            .requestMatchers(AntPathRequestMatcher.antMatcher("/janken/**")).authenticated() // /sample3/以下は認証済みであること
-            .requestMatchers(AntPathRequestMatcher.antMatcher("/**")).permitAll()); // それ以外は全員アクセス可能
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/janken/**")).authenticated() // /janken/以下は認証済みであること
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/**")).permitAll()) // それ以外は全員アクセス可能
+        .csrf(csrf -> csrf
+            .ignoringRequestMatchers(AntPathRequestMatcher.antMatcher("/h2-console/*")))
+        .headers(headers -> headers
+            .frameOptions(frameOptions -> frameOptions
+                .sameOrigin()));
     return http.build();
   }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,14 @@
-
+server.port=8080
+spring.sql.init.encoding=UTF-8
+spring.datasource.url=jdbc:h2:mem:janken
+# DBを永続化したければ↓のように指定する(memはインメモリなのでSpringbootを終了すると消える)
+# 参考：https://qiita.com/5zm/items/4916d517b45ca9dc5a4b
+#spring.datasource.url=jdbc:h2:./h2db/janken
+# H2DBを利用する場合のドライバ名，ユーザ名，パスワード（なし）
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled:true
+# LOG種別の指定ERROR、WARN、INFO、DEBUG、TRACE
+# 参考：https://cloud.ibm.com/docs/java?topic=java-spring-logging&locale=ja
+logging.level.root=INFO


### PR DESCRIPTION
application.propertiesにデータベース関連の設定を実施する
server.portは8080とする(server.port=8080)
spring.datasource.urlはjdbc:h2:mem:jankenに変更する
h2-consoleにアクセスできるようにspring.h2.console.enabled:trueを追加しておく
JankenAuthConfiguration.javaにh2-consoleにアクセスするための設定を追記する