### PR TITLE
ログイン後にアクティブな試合を表示

### DIFF
--- a/src/main/java/oit/is/z1732/kaizi/janken/controller/JankenController.java
+++ b/src/main/java/oit/is/z1732/kaizi/janken/controller/JankenController.java
@@ -54,6 +54,9 @@ public class JankenController {
     ArrayList<User> entryUsers = userMapper.selectAllUser();
     model.addAttribute("entryUsers", entryUsers);
 
+    ArrayList<MatchInfo> activeMatches = matchInfoMapper.selectActiveMatch();
+    model.addAttribute("activeMatches", activeMatches);
+
     ArrayList<Match> matchResults = matchMapper.selectAllMatch();
     model.addAttribute("matchResults", matchResults);
 

--- a/src/main/java/oit/is/z1732/kaizi/janken/model/MatchInfoMapper.java
+++ b/src/main/java/oit/is/z1732/kaizi/janken/model/MatchInfoMapper.java
@@ -1,12 +1,18 @@
 package oit.is.z1732.kaizi.janken.model;
 
+import java.util.ArrayList;
+
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Select;
 
 @Mapper
 public interface MatchInfoMapper {
   @Insert("Insert INTO matchinfo (user1,user2,user1Hand,isActive) VALUES (#{user1},#{user2},#{user1Hand},true);")
   @Options(useGeneratedKeys = true, keyColumn = "id", keyProperty = "id")
   void insertMatchInfo(MatchInfo matchInfo);
+
+  @Select("SELECT * from matchinfo where isActive = true")
+  ArrayList<MatchInfo> selectActiveMatch();
 }

--- a/src/main/resources/templates/janken.html
+++ b/src/main/resources/templates/janken.html
@@ -20,6 +20,19 @@
     </ul>
   </div>
 
+  <h2>アクティブな試合</h2>
+  <p th:if="${activeMatches}">
+  <div th:each="activeMatch:${activeMatches}">
+    <tr>
+      <td>id:[[${activeMatch.id}]]</td>
+      <td>user1:[[${activeMatch.user1}]]</td>
+      <td>user2:[[${activeMatch.user2}]]</td>
+      <td>isActive:[[${activeMatch.isActive}]]</td>
+    </tr>
+  </div>
+  </p>
+
+  <h2>試合結果</h2>
   <p th:if="${matchResults}">
   <div th:each="matchResult:${matchResults}">
     <tr>


### PR DESCRIPTION
「ほんだ」でログイン後の画面でmatchinfoテーブルのisActiveがtrueとして登録される試合を表示する
流れ
「いがき」でログインし，jankenのページのエントリーから「ほんだ」を選び，matchのページで手を選び，waitのページに遷移する
シークレットモードで「ほんだ」でログインし，jankenのページでアクティブな試合について「id:(MatchInfoのidが表示される) user1:(MatchInfoのuser1が表示される) user2:(MatchInfoのuser1が表示される) isActive:(MatchInfoのisActiveが表示される)」の様に表示される